### PR TITLE
fixed url relativity

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ hexo.extend.generator.register('spoiler_asset', () => [
 ]);
 
 hexo.extend.filter.register('after_post_render', (data) => {
-    var link_css = "<link rel=\"stylesheet\" href=\"/css/spoiler.css\" type=\"text/css\">";
-    var link_js = "<script src=\"/js/spoiler.js\" type=\"text/javascript\" async></script>";
+    var link_css = "<link rel=\"stylesheet\" href=\""+hexo.config.root+"css/spoiler.css\" type=\"text/css\">";
+    var link_js = "<script src=\""+hexo.config.root+"js/spoiler.js\" type=\"text/javascript\" async></script>";
     data.content += link_css + link_js;
     return data;
 });

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ hexo.extend.generator.register('spoiler_asset', () => [
 
 hexo.extend.filter.register('after_post_render', (data) => {
     var link_css = "<link rel=\"stylesheet\" href=\""+hexo.config.root+"css/spoiler.css\" type=\"text/css\">";
-    var link_js = "<script src=\""+hexo.config.root+"js/spoiler.js\" type=\"text/javascript\" async></script>";
+    let link_js = `<script src="${hexo.config.root}js/spoiler.js" type="text/javascript" async></script>`;
     data.content += link_css + link_js;
     return data;
 });

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ hexo.extend.generator.register('spoiler_asset', () => [
 ]);
 
 hexo.extend.filter.register('after_post_render', (data) => {
-    var link_css = "<link rel=\"stylesheet\" href=\""+hexo.config.root+"css/spoiler.css\" type=\"text/css\">";
+    let link_css = `<link rel="stylesheet" href="${hexo.config.root}css/spoiler.css" type="text/css">`;
     let link_js = `<script src="${hexo.config.root}js/spoiler.js" type="text/javascript" async></script>`;
     data.content += link_css + link_js;
     return data;


### PR DESCRIPTION
spoiler.css and spoiler.js were being pulled from root '/'.  This fix makes them acknowledge the 'root' parameter of the _config.yml (so, for example, if your blog is hosted at somedomain.com/blog, it'll pull spoiler.css from somedomain.com/blog/spoiler.css instead of somedomain.com/spoiler.css)