### PR TITLE
Resolve Conflict between hexo-sliding-spoiler and hexo-spoiler plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ plugins:
 ## Syntax
 
 ```plain
-{% spoiler title %}
+{% sspoiler title %}
 content
-{% endspoiler %}
+{% endsspoiler %}
 ```
 
 It will hide your text and place the title at the top with a dropdown/scroll up arrow.
@@ -32,16 +32,16 @@ It will hide your text and place the title at the top with a dropdown/scroll up 
 ### One word title
 
 ```plain
-{% spoiler word %}
+{% sspoiler word %}
 content
-{% endspoiler %}
+{% endsspoiler %}
 ```
 
 ### Title containing spaces
 
 
 ```plain
-{% spoiler "Several spaces in the title" %}
+{% sspoiler "Several spaces in the title" %}
 content
-{% endspoiler %}
+{% endsspoiler %}
 ```

--- a/assets/spoiler.css
+++ b/assets/spoiler.css
@@ -1,4 +1,4 @@
-.spoiler {
+.sspoiler {
     margin: 5px 0;
     padding: 0 15px;
     border: 1px solid #E5E5E5;
@@ -7,7 +7,7 @@
     border-radius: 3px;
 }
 
-.spoiler .spoiler-title {
+.sspoiler .sspoiler-title {
     background: #E5E5E5;
     margin: 0 -15px;
     padding: 5px 15px;
@@ -18,19 +18,19 @@
     cursor: pointer;
 }
 
-.spoiler .spoiler-title:before {
+.sspoiler .sspoiler-title:before {
     font-weight: bold;
 }
 
-.spoiler.collapsed .spoiler-title:before {
+.sspoiler.collapsed .sspoiler-title:before {
     content: "Show ";
 }
 
-.spoiler.expanded .spoiler-title:before {
+.sspoiler.expanded .sspoiler-title:before {
     content: "Hide ";
 }
 
-.spoiler .spoiler-content {
+.sspoiler .sspoiler-content {
     padding-top: 0;
     padding-bottom: 0;
     margin-top: 0;
@@ -45,16 +45,16 @@
     transition-timing-function: ease-in-out;
 }
 
-.spoiler.collapsed .spoiler-content {
+.sspoiler.collapsed .sspoiler-content {
     overflow: hidden;
     max-height: 0;
 }
 
-.spoiler.expanded .spoiler-content {
+.sspoiler.expanded .sspoiler-content {
     max-height: 3000px;
     overflow: hidden;
 }
 
-.spoiler .spoiler-content p:first-child {
+.sspoiler .sspoiler-content p:first-child {
     margin-top: 0 !important;
 }

--- a/assets/spoiler.js
+++ b/assets/spoiler.js
@@ -1,6 +1,6 @@
 (function (document) {
-    [].forEach.call(document.getElementsByClassName('spoiler'), function(panel) {
-        panel.getElementsByClassName('spoiler-title')[0].onclick = function() {
+    [].forEach.call(document.getElementsByClassName('sspoiler'), function(panel) {
+        panel.getElementsByClassName('sspoiler-title')[0].onclick = function() {
             panel.classList.toggle("collapsed");
             panel.classList.toggle("expanded");
         }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 const fs = require('hexo-fs');
 const path = require('path');
 
-hexo.extend.tag.register('spoiler', (args, content) =>
-`<div class='spoiler collapsed'>
-    <div class='spoiler-title'>
+hexo.extend.tag.register('sspoiler', (args, content) =>
+`<div class='sspoiler collapsed'>
+    <div class='sspoiler-title'>
         ${args.join(" ")}
     </div>
-    <div class='spoiler-content'>
+    <div class='sspoiler-content'>
         ${
             hexo.render.renderSync({
                 text: content,
@@ -18,7 +18,7 @@ hexo.extend.tag.register('spoiler', (args, content) =>
     ends: true
 });
 
-hexo.extend.generator.register('spoiler_asset', () => [
+hexo.extend.generator.register('sspoiler_asset', () => [
     {
         path: 'css/spoiler.css',
         data: function () {


### PR DESCRIPTION
## Description
This pull request addresses the conflict issue encountered in the hexo-sliding-spoiler project when both hexo-sliding-spoiler and hexo-spoiler plugins are enabled. The conflict arises due to the shared use of the same tag {% spoiler %}, resulting in only one of the plugins functioning correctly depending on their loading order.

## Solution
To resolve this conflict, I have made the following modifications in the hexo-sliding-spoiler project:
1. Changed the class and tag names from {% spoiler %} to {% sspoiler %}, where "sspoiler" represents "sliding-spoiler".
2. Update the README document.

By implementing these changes, the hexo-sliding-spoiler plugin now has a unique tag that distinguishes it from the hexo-spoiler plugin. This ensures that both plugins can be enabled simultaneously without conflicts, as each plugin will respond to its respective tag.

I kindly request the project maintainers to review and consider merging this pull request. This solution will greatly enhance the compatibility and usability of the hexo-sliding-spoiler plugin. Thank you for your attention to this matter!