### PR TITLE
Fix spoiler rendering on index and archive pages

### DIFF
--- a/assets/spoiler.js
+++ b/assets/spoiler.js
@@ -1,8 +1,8 @@
-(function (document) {
+document.addEventListener('DOMContentLoaded', function () {
     [].forEach.call(document.getElementsByClassName('spoiler'), function(panel) {
         panel.getElementsByClassName('spoiler-title')[0].onclick = function() {
             panel.classList.toggle("collapsed");
             panel.classList.toggle("expanded");
         }
     });
-})(document);
+});

--- a/index.js
+++ b/index.js
@@ -33,9 +33,21 @@ hexo.extend.generator.register('spoiler_asset', () => [
     }
 ]);
 
-hexo.extend.filter.register('after_post_render', (data) => {
-    let link_css = `<link rel="stylesheet" href="${hexo.config.root}css/spoiler.css" type="text/css">`;
-    let link_js = `<script src="${hexo.config.root}js/spoiler.js" type="text/javascript" async></script>`;
-    data.content += link_css + link_js;
-    return data;
+// Inject CSS into <head> and JS before </body> on any page containing a spoiler.
+// This replaces the previous after_post_render approach which only added assets to
+// data.content — that failed on index/archive pages where themes render excerpts
+// instead of the full post content.
+hexo.extend.filter.register('after_render:html', (str) => {
+    if (!str.includes('class=\'spoiler') && !str.includes('class="spoiler')) {
+        return str;
+    }
+
+    const root = hexo.config.root || '/';
+    const link_css = `<link rel="stylesheet" href="${root}css/spoiler.css" type="text/css">`;
+    const link_js = `<script src="${root}js/spoiler.js" type="text/javascript"></script>`;
+
+    str = str.replace('</head>', link_css + '</head>');
+    str = str.replace('</body>', link_js + '</body>');
+
+    return str;
 });


### PR DESCRIPTION
## Problem

Spoilers do not render properly on the front/index page — they only work on individual article pages (fixes #13).

### Root cause

The CSS and JS assets were injected via `after_post_render` into `data.content`. On index and archive pages, most Hexo themes render `post.excerpt` or truncated content rather than the full `data.content`, so the `<link>` and `<script>` tags were never included in the page output.

Additionally, the JS used an IIFE that executed immediately on script load. With the `async` attribute, the script could run before spoiler elements were present in the DOM.

## Changes

- **`index.js`**: Replace `after_post_render` filter with `after_render:html` filter that injects CSS into `<head>` and JS before `</body>` on any page containing spoiler markup. Assets are only injected on pages that actually contain spoilers.
- **`assets/spoiler.js`**: Switch from an IIFE to a `DOMContentLoaded` listener to ensure all spoiler elements are in the DOM before binding click handlers. Remove `async` attribute from the script tag since timing is now handled by the event listener.