### PR TITLE
ci: add publish workflow with trusted publishing, dependabot, and housekeeping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Publish to GitHub Packages
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Publish to GitHub Packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
   packages: write
 
@@ -39,3 +39,14 @@ jobs:
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [publish-npm, publish-gpr]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Create GitHub Release
+        run: gh release create "${{ github.ref_name }}" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -28,9 +28,9 @@ jobs:
   publish-gpr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,13 @@ on:
 
 permissions:
   contents: read
+  id-token: write
   packages: write
 
 jobs:
-  publish:
+  publish-npm:
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - uses: actions/checkout@v4
 
@@ -21,9 +23,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
+
+  publish-gpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,0 @@
-img/
-.github/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "fletchto99",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "bugs": {
     "url": "https://github.com/fletchto99/hexo-sliding-spoiler/issues"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "fletchto99",
   "license": "MIT",
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "bugs": {
     "url": "https://github.com/fletchto99/hexo-sliding-spoiler/issues"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0",
   "description": "A sliding spoiler creator for Hexo, inspired by hexo-spoiler",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "assets/"
+  ],
   "scripts": {
     "test": "echo \"Error: tests not implemented\" && exit 1"
   },
@@ -12,13 +16,16 @@
   },
   "keywords": [
     "hexo",
-    "spoiler"
+    "spoiler",
+    "sliding-spoiler"
   ],
   "author": "fletchto99",
   "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
   "bugs": {
     "url": "https://github.com/fletchto99/hexo-sliding-spoiler/issues"
   },
-  "homepage": "https://github.com/fletchto99/hexo-sliding-spoiler",
-  "dependencies": {}
+  "homepage": "https://github.com/fletchto99/hexo-sliding-spoiler"
 }

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/fletchto99/hexo-sliding-spoiler/issues"
   },
-  "homepage": "https://github.com/fletchto99/hexo-sliding-spoiler"
+  "homepage": "https://github.com/fletchto99/hexo-sliding-spoiler",
+  "publishConfig": {
+    "provenance": true
+  }
 }


### PR DESCRIPTION
## Changes

- **Publish workflow** triggered on `v*` tags — npm via OIDC trusted publishing with `--provenance`, GitHub Packages via `GITHUB_TOKEN`
- **Dependabot** for weekly GitHub Actions version updates
- `.gitignore` added (`node_modules/`)
- **package.json** housekeeping: `files` array (replaces `.npmignore`), `engines` field, `publishConfig.provenance`, `sliding-spoiler` keyword, removed empty `dependencies`
- **Bug fix** for issue #14 (spoiler CSS/JS fixes)
- **README** updates

## Setup before first publish

1. Create an `npm` environment in **Settings → Environments**
2. Link the repo to the npm package for [trusted publishing](https://docs.npmjs.com/generating-provenance-statements#linking-an-existing-package-to-a-github-repository)

Closes #14