### PR TITLE
fix(ci): fix GPR auth and decouple release from GPR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,13 +36,14 @@ jobs:
           registry-url: 'https://npm.pkg.github.com'
 
       - name: Publish to GitHub Packages
-        run: npm publish --access public
+        run: npm publish --registry https://npm.pkg.github.com --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     runs-on: ubuntu-latest
-    needs: [publish-npm, publish-gpr]
+    needs: [publish-npm]
+    if: always() && needs.publish-npm.result == 'success'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Fixes

- **GPR publish**: Added explicit `--registry https://npm.pkg.github.com` to prevent npm from defaulting to npmjs.org (caused `ENEEDAUTH`)
- **Release job**: Now only depends on npm publish success, so a GPR failure won't block the GitHub Release

## npm trusted publishing (manual step)

The npm publish job got a 404 because the package needs to be linked for OIDC trusted publishing. Go to [npmjs.com/package/hexo-sliding-spoiler](https://www.npmjs.com/package/hexo-sliding-spoiler) → **Settings** → **Publishing access** and link the GitHub repo.