### PR TITLE
fix(ci): remove environment from npm publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
-    environment: npm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
The npm trusted publishing OIDC config has no environment set, so the workflow must not specify one either — they need to match exactly or npm rejects the token with a 404.