### PR TITLE
fix(ci): remove registry-url to fix npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
         run: npm publish --provenance --access public
@@ -45,8 +44,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: [publish-npm]
-    if: always() && needs.publish-npm.result == 'success'
+    needs: [publish-npm, publish-gpr]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
`setup-node` with `registry-url` creates an `.npmrc` that sets `NODE_AUTH_TOKEN` to `GITHUB_TOKEN`, which overrides npm's OIDC trusted publishing flow. Removing `registry-url` from the npm job lets npm handle OIDC authentication natively via `--provenance`.