### PR TITLE
fix(ci): restore registry-url for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
Restores `registry-url` to the npm publish job. It's needed so npm knows which registry to authenticate against. The previous 404 errors were caused by the `environment: npm` mismatch (already fixed in PR #25). This is the first run with both fixes combined.